### PR TITLE
Fix uninitialized warnings from dir_path and path

### DIFF
--- a/lib/HTML/Mason/Component.pm
+++ b/lib/HTML/Mason/Component.pm
@@ -111,18 +111,21 @@ sub _determine_inheritance {
 
     my $interp = $self->interp;
 
+    my $dir_path = $self->dir_path;
+    $dir_path = '' unless defined $dir_path;
+
     # Assign inheritance properties
     if (exists($self->{flags}->{inherit})) {
         if (defined($self->{flags}->{inherit})) {
-            $self->{inherit_path} = absolute_comp_path($self->{flags}->{inherit}, $self->dir_path);
+            $self->{inherit_path} = absolute_comp_path($self->{flags}->{inherit}, $dir_path);
         }
     } elsif ( $interp->use_autohandlers ) {
         if ($self->name eq $interp->autohandler_name) {
-            unless ($self->dir_path eq '/') {
-                ($self->{inherit_start_path}) = $self->dir_path =~ m,^(.*/)?.*,s
+            unless ($dir_path eq '/') {
+                ($self->{inherit_start_path}) = $dir_path =~ m,^(.*/)?.*,s
             }
         } else {
-            $self->{inherit_start_path} = $self->dir_path;
+            $self->{inherit_start_path} = $dir_path;
         }
     }
 }
@@ -378,7 +381,9 @@ sub logger {
     my ($self) = @_;
 
     if (!$self->{logger}) {
-        my $log_category = "HTML::Mason::Component" . $self->path();
+        my $path = $self->path();
+        $path = '' unless defined $path;
+        my $log_category = "HTML::Mason::Component$path";
         $log_category =~ s/\//::/g;
         $self->{logger} = Log::Any->get_logger(category => $log_category);
     }

--- a/lib/HTML/Mason/Request.pm
+++ b/lib/HTML/Mason/Request.pm
@@ -255,6 +255,7 @@ sub _initialize {
                 unless ($request_comp) {
                     if ( $request_comp = $self->interp->find_comp_upwards($path, $self->dhandler_name) ) {
                         my $parent_path = $request_comp->dir_path;
+                        $parent_path = '' unless defined $parent_path;
                         ($self->{dhandler_arg} = $self->{top_path}) =~ s{^$parent_path/?}{};
                         $log->debugf("found dhandler '%s', dhandler_arg '%s'", $parent_path, $self->{dhandler_arg})
                             if $log->is_debug;
@@ -266,6 +267,7 @@ sub _initialize {
                 # tree. 
                 if ($request_comp and $self->{declined_comps}->{$request_comp->comp_id}) {
                     $path = $request_comp->dir_path;
+                    $path = '' unless defined $path;
                     if ($request_comp->name eq $self->dhandler_name) {
                         if ($path eq '/') {
                             undef $request_comp;
@@ -587,7 +589,9 @@ sub make_subrequest
     # Coerce a string 'comp' parameter into an absolute path.  Don't
     # create it if it's missing, though - it's required, but for
     # consistency we let exceptions be thrown later.
-    $params{comp} = absolute_comp_path($params{comp}, $self->current_comp->dir_path)
+    my $dir_path = $self->current_comp->dir_path;
+    $dir_path = '' unless defined $dir_path;
+    $params{comp} = absolute_comp_path($params{comp}, $dir_path)
         if exists $params{comp} && !ref($params{comp});
 
     # Give subrequest the same values as parent request for read/write params
@@ -1123,7 +1127,9 @@ sub _fetch_comp
     #
     # Otherwise pass the canonicalized absolute path to interp->load.
     #
-    $path = absolute_comp_path($path, $current_comp->dir_path);
+    my $dir_path = $current_comp->dir_path;
+    $dir_path = '' unless defined $dir_path;
+    $path = absolute_comp_path($path, $dir_path);
     my $comp = $self->interp->load($path);
 
     return $comp;


### PR DESCRIPTION
Use empty string “” when dir_path or path return undef.  This addresses
bug 55159.